### PR TITLE
fix(types): add types to named export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "types": "./lib/types/index.d.ts",
   "main": "./lib/cjs/index.js",
   "exports": {
-    ".": "./lib/cjs/index.js"
+    ".": {
+      "default":  "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
+    }
   },
   "sideEffects": false,
   "engines": {


### PR DESCRIPTION
A reasonable resolution to https://github.com/warp-contracts/warp-contracts-lmdb/issues/27

Current workaround `tsconfig.json`

```
"paths": {
  "warp-contracts-lmdb": ["./node_modules/warp-contracts-lmdb/lib/types/index.d.ts"]
}
```